### PR TITLE
fix: prevent autofill from changing name input background to white

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,3 +5,13 @@
 body {
   @apply text-gray-100 bg-gray-800;
 }
+
+/* Prevent autofill from changing input background color */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  -webkit-box-shadow: 0 0 0 30px rgb(75 85 99) inset !important;
+  -webkit-text-fill-color: rgb(243 244 246) !important;
+  transition: background-color 5000s ease-in-out 0s;
+}


### PR DESCRIPTION
Fixes #3

Added CSS rules to override browser autofill styling and maintain the gray-600 background color for input fields. This fixes the issue where selecting an autofill option would change the background to white.

Generated with [Claude Code](https://claude.ai/code)