### PR TITLE
feat: remove empty rows when calculate button is clicked

### DIFF
--- a/app/pages/home/InputForm.tsx
+++ b/app/pages/home/InputForm.tsx
@@ -67,13 +67,22 @@ const InputForm: React.FC<{}> = (props) => {
   function calculate(players: Player[]) {
     console.log("current players: ");
     console.log(players);
+
+    // Filter out empty rows (rows with no name or with empty name and zero net)
+    const filteredPlayers = players.filter(player => {
+      return player.name && player.name.trim() !== '';
+    });
+
+    // Update the ledger to remove empty rows
+    setLedger(filteredPlayers);
+
     let sum = 0;
     let positives: Player[] = new Array();
     let negatives: Player[] = new Array();
 
     setCalculated(true);
 
-    players.forEach((player) => {
+    filteredPlayers.forEach((player) => {
       sum = sum + player.net;
       if (player.net > 0) {
         positives.push({ ...player });


### PR DESCRIPTION
When users add extra rows with the + button but don't use them, those empty rows are now automatically removed when they click Calculate. Only rows with valid player names are kept in the ledger.

Fixes #5

Generated with [Claude Code](https://claude.ai/code)