### PR TITLE
fix: display 0 for net score instead of blank

### DIFF
--- a/app/pages/home/InputRow.tsx
+++ b/app/pages/home/InputRow.tsx
@@ -66,7 +66,7 @@ const InputRow: React.FC<{
           id="netVal"
           className=" bg-gray-400 rounded w-20 h-6 mx-1 px-2 text-gray-700"
         >
-          {props.player.net ? convertToPounds(props.player.net) : null}
+          {props.player.net != null ? convertToPounds(props.player.net) : null}
         </div>
         {/* <button
           className="p-2 content-center flex border bg-gray-600 font-medium rounded hover:font-bold active:text-gray-400 active: border-gray-400 disabled:bg-gray-700 disabled:border-none"


### PR DESCRIPTION
When net score is 0, it should display '£0.00' instead of showing blank.

Changed the conditional check from truthy check to explicit null check in `app/pages/home/InputRow.tsx`.

Fixes #11

---
Generated with [Claude Code](https://claude.ai/code)