### PR TITLE
fix: remove horizontal scrollbar by replacing w-screen with w-full

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import InputForm from "./pages/home/InputForm";
 
 export default function Home() {
   return (
-    <div className="min-h-screen w-screen flex flex-col items-center">
+    <div className="min-h-screen w-full flex flex-col items-center">
       <div className="flex-grow flex flex-col justify-center items-center w-full">
         {/* <div className="py-2"></div> */}
         <div className="text-2xl text-center">payout_calculator</div>

--- a/app/split-the-discrepancy/page.tsx
+++ b/app/split-the-discrepancy/page.tsx
@@ -1,6 +1,6 @@
 export default function SplitTheDiscrepancy() {
   return (
-    <div className="min-h-screen w-screen flex flex-col items-center p-8">
+    <div className="min-h-screen w-full flex flex-col items-center p-8">
       <div className="max-w-2xl">
         <h1 className="text-2xl font-bold mb-6">Split the Discrepancy</h1>
 


### PR DESCRIPTION
Fixes the horizontal scroll bar issue where an unnecessary horizontal scrollbar appeared when vertical content expanded.

## Changes
- Replaced `w-screen` with `w-full` in `app/page.tsx`
- Replaced `w-screen` with `w-full` in `app/split-the-discrepancy/page.tsx`

## Root Cause
The `w-screen` class uses `width: 100vw` which includes the scrollbar width, causing horizontal overflow. The `w-full` class uses `width: 100%` which respects the available viewport width.

Fixes #15

Generated with [Claude Code](https://claude.ai/code)