### PR TITLE
fix: hide number input stepper arrows on desktop

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -15,3 +15,14 @@ input:-webkit-autofill:active {
   -webkit-text-fill-color: rgb(243 244 246) !important;
   transition: background-color 5000s ease-in-out 0s;
 }
+
+/* Hide number input stepper arrows */
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type="number"] {
+  -moz-appearance: textfield;
+}


### PR DESCRIPTION
Closes #17

This PR removes the stepper arrows from the number input fields for In and Out values on desktop browsers.

### Changes
- Added CSS rules to hide WebKit stepper arrows (Chrome, Safari, Edge)
- Added CSS rules to hide Firefox stepper arrows

Generated with [Claude Code](https://claude.ai/code)